### PR TITLE
chore: ignore CLAUDE.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ _site
 .hadolint.yaml
 .markdownlint.yaml
 .shellcheckrc
+CLAUDE.md


### PR DESCRIPTION
Add `CLAUDE.md` to `.gitignore` so local Claude Code context files don't appear as untracked changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)